### PR TITLE
Fix propagation of the expire time

### DIFF
--- a/2q_test.go
+++ b/2q_test.go
@@ -3,6 +3,7 @@ package lru
 import (
 	"math/rand"
 	"testing"
+	"time"
 )
 
 func Benchmark2Q_Rand(b *testing.B) {
@@ -302,5 +303,29 @@ func Test2Q_Peek(t *testing.T) {
 	l.Add(3, 3)
 	if l.Contains(1) {
 		t.Errorf("should not have updated recent-ness of 1")
+	}
+}
+
+// Test that values expire as expected
+func Test2Q_Expire(t *testing.T) {
+	l, err := New2Q(100)
+	if err != nil {
+		t.Fatalf("failed to create LRU: %v", err)
+	}
+
+	l.AddEx("hey", "hello", 300*time.Millisecond)
+
+	value, ok := l.Get("hey")
+	if !ok {
+		t.Fatal("failed to read back value")
+	}
+	if value.(string) != "hello" {
+		t.Errorf("expected \"hello\", got %v", value)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	_, ok = l.Get("hey")
+	if ok {
+		t.Errorf("cached didn't properly expire")
 	}
 }

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -136,13 +136,21 @@ func (c *LRU) Contains(key interface{}) (ok bool) {
 // Returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
 func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	v, _, ok := c.PeekWithExpireTime(key)
+	return v, ok
+}
+
+// Returns the key value (or undefined if not found) and its associated expire
+// time without updating the "recently used"-ness of the key.
+func (c *LRU) PeekWithExpireTime(key interface{}) (
+	value interface{}, expire *time.Time, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		if ent.Value.(*entry).IsExpired() {
-			return nil, false
+			return nil, nil, false
 		}
-		return ent.Value.(*entry).value, true
+		return ent.Value.(*entry).value, ent.Value.(*entry).expire, true
 	}
-	return nil, ok
+	return nil, nil, ok
 }
 
 // Remove removes the provided key from the cache, returning if the


### PR DESCRIPTION
When moving values from the recent queue into the frequent queue, the previous implementation of the `Get` method would incorrectly reset the expire time to the default value.