### PR TITLE
Added new constructor function 

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -46,6 +46,19 @@ func NewWithExpire(size int, expire time.Duration) (*Cache, error) {
 	return c, nil
 }
 
+// NewWithExpireAndEvict constructs a fixed size cache with expire 
+//and with the given eviction callback
+func NewWithExpireAndEvict(size int, expire time.Duration, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
+	lru, err := simplelru.NewLRUWithExpire(size, expire, simplelru.EvictCallback(onEvicted))
+	if err != nil {
+		return nil, err
+	}
+	c := &Cache{
+		lru: lru,
+	}
+	return c, nil
+}
+
 // Purge is used to completely clear the cache
 func (c *Cache) Purge() {
 	c.lock.Lock()


### PR DESCRIPTION
- Added new constructor function that allows you to create a new atomic LRU with both a default expiration time and an eviction handler
   - Without this function, users would have to manually have to add the cache expiration time on every value they add to the cache if they choose to have an eviction handler
   - Seems like a natural addition since this already exists on the non-atomic version (`simplelru`)